### PR TITLE
Correct end stream handling in DecryptingChannel

### DIFF
--- a/jagged-framework/src/main/java/com/exceptionfactory/jagged/framework/stream/DecryptingChannel.java
+++ b/jagged-framework/src/main/java/com/exceptionfactory/jagged/framework/stream/DecryptingChannel.java
@@ -108,7 +108,9 @@ final class DecryptingChannel implements ReadableByteChannel {
 
             final int plainBufferRead = readPlainBuffer(outputBuffer);
             if (END_OF_FILE == plainBufferRead) {
-                read = END_OF_FILE;
+                if (read == 0) {
+                    read = END_OF_FILE;
+                }
                 break;
             } else {
                 read += plainBufferRead;

--- a/jagged-framework/src/test/java/com/exceptionfactory/jagged/framework/stream/DecryptingChannelTest.java
+++ b/jagged-framework/src/test/java/com/exceptionfactory/jagged/framework/stream/DecryptingChannelTest.java
@@ -206,9 +206,13 @@ class DecryptingChannelTest {
 
         outputBuffer.position(0);
         final int secondDecrypted = decryptingChannel.read(outputBuffer);
-        assertEquals(END_OF_FILE, secondDecrypted);
+        assertEquals(HALF_BUFFER_SIZE, secondDecrypted);
 
         assertArrayEquals(inputBytes, outputBuffer.array());
+
+        outputBuffer.position(0);
+        final int thirdDecrypted = decryptingChannel.read(outputBuffer);
+        assertEquals(END_OF_FILE, thirdDecrypted);
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses end of stream handling in `DecryptingChannel.read()` described in issue #1.

Jagged 0.3.0 and earlier return `-1` from `read()` as soon as `DecryptingChannel.read()` finishes reading and decrypting the end of the wrapped `ReadableByteChannel`. As a result of this approach, `DecryptingChannel.read()` can add bytes to the provided `ByteBuffer` but return `-1` instead of the number of bytes read. This can cause problems when reading from channels that wrap or represent socket sources.

The changes in this pull request modify the `read()` method to return the number of bytes read into the provided `ByteBuffer`, and only return `-1` for end of stream when processing the decrypted wrapped channel results in zero bytes read.