### PR TITLE
Correct Channel.close() on repeated invocation

### DIFF
--- a/jagged-framework/src/main/java/com/exceptionfactory/jagged/framework/armor/ArmoredWritableByteChannel.java
+++ b/jagged-framework/src/main/java/com/exceptionfactory/jagged/framework/armor/ArmoredWritableByteChannel.java
@@ -111,12 +111,13 @@ final class ArmoredWritableByteChannel implements WritableByteChannel {
      */
     @Override
     public void close() throws IOException {
-        if (lineBuffer.position() > 0) {
-            writeLineBuffer();
+        if (outputChannel.isOpen()) {
+            if (lineBuffer.position() > 0) {
+                writeLineBuffer();
+            }
+            writeFooter();
+            outputChannel.close();
         }
-
-        writeFooter();
-        outputChannel.close();
     }
 
     private void writeHeader() throws IOException {

--- a/jagged-framework/src/main/java/com/exceptionfactory/jagged/framework/stream/EncryptingChannel.java
+++ b/jagged-framework/src/main/java/com/exceptionfactory/jagged/framework/stream/EncryptingChannel.java
@@ -121,11 +121,12 @@ final class EncryptingChannel implements WritableByteChannel {
      */
     @Override
     public void close() throws IOException {
-        payloadIvParameterSpec.setLastChunkFlag();
-        flushInputBuffer();
-
-        outputChannel.close();
-        payloadKey.destroy();
+        if (outputChannel.isOpen()) {
+            payloadIvParameterSpec.setLastChunkFlag();
+            flushInputBuffer();
+            outputChannel.close();
+            payloadKey.destroy();
+        }
     }
 
     private void flushInputBuffer() throws IOException {

--- a/jagged-framework/src/test/java/com/exceptionfactory/jagged/framework/armor/ArmoredWritableByteChannelTest.java
+++ b/jagged-framework/src/test/java/com/exceptionfactory/jagged/framework/armor/ArmoredWritableByteChannelTest.java
@@ -104,6 +104,9 @@ class ArmoredWritableByteChannelTest {
         final byte[] armored = outputStream.toByteArray();
         final byte[] expected = getExpected(LINE_EXPECTED, LINE_EXPECTED, LINE_EXPECTED);
         assertArrayEquals(expected, armored);
+
+        channel.close();
+        assertFalse(channel.isOpen());
     }
 
     @Test

--- a/jagged-framework/src/test/java/com/exceptionfactory/jagged/framework/stream/EncryptingChannelTest.java
+++ b/jagged-framework/src/test/java/com/exceptionfactory/jagged/framework/stream/EncryptingChannelTest.java
@@ -93,6 +93,21 @@ class EncryptingChannelTest {
     }
 
     @Test
+    void testCloseRepeated() throws GeneralSecurityException, IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final EncryptingChannel encryptingChannel = getEncryptingChannel(outputStream);
+
+        encryptingChannel.close();
+        assertFalse(encryptingChannel.isOpen());
+
+        encryptingChannel.close();
+        assertFalse(encryptingChannel.isOpen());
+
+        final byte[] bytes = outputStream.toByteArray();
+        assertEquals(EMPTY_ENCRYPTED_LENGTH, bytes.length);
+    }
+
+    @Test
     void testEmpty() throws GeneralSecurityException, IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final EncryptingChannel encryptingChannel = getEncryptingChannel(outputStream);


### PR DESCRIPTION
This pull request corrects the behavior of `EncryptingChannel.close()` and `ArmoredWritableByteChannel.close()` on repeated invocations, raised in issue #3.

The behavior of these methods in Jagged 3.1 and earlier writes remaining buffer information then closes the output channel. On subsequent invocations, attempts to write buffered information throws a `ClosedChannelException`.

Checking that the output channel is open avoids repeated write attempts and allows the close method to be invoked multiple times without causing exceptions.