### PR TITLE
Add jagged-ssh module with support for SSH RSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ framework for the following algorithms:
 - `ChaCha20-Poly1305` with [javax.crypto.Cipher](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/Cipher.html)
 - `HmacSHA256` with [javax.crypto.Mac](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/Mac.html)
 - `PBKDF2WithHmacSHA256` with [javax.crypto.SecretKeyFactory](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/SecretKeyFactory.html)
+- `RSA/ECB/OAEPPadding` with [javax.crypto.Cipher](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/Cipher.html)
 - `X25519` with [javax.crypto.KeyAgreement](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/KeyAgreement.html)
 - `X25519` with [java.security.KeyFactory](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/security/KeyFactory.html)
 - `X25519` with [java.security.KeyPairGenerator](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/security/KeyPairGenerator.html)
@@ -63,6 +64,7 @@ Jagged supports streaming encryption and decryption using standard recipient typ
 - Encryption and decryption of [armored age files](https://github.com/C2SP/C2SP/blob/main/age.md#ascii-armor)
 - [X25519](https://github.com/C2SP/C2SP/blob/main/age.md#the-x25519-recipient-type) recipients and identities
 - [scrypt](https://github.com/C2SP/C2SP/blob/main/age.md#the-scrypt-recipient-type) recipients and identities
+- [ssh-rsa](https://github.com/FiloSottile/age/blob/main/README.md#ssh-keys) recipients and identities
 
 # Specifications
 
@@ -117,6 +119,10 @@ a File Key.
 
 The scrypt type encrypts a File Key with ChaCha20-Poly1305.
 
+The ssh-rsa type encrypts a File Key with RSA-OAEP.
+
+- [RFC 8017](https://www.rfc-editor.org/rfc/rfc8017) PKCS #1: RSA Cryptography Specifications Version 2.2
+
 # Modules
 
 Jagged consists of multiple modules supporting different aspects of the age encryption specification.
@@ -125,6 +131,7 @@ Jagged consists of multiple modules supporting different aspects of the age encr
 - jagged-bech32
 - jagged-framework
 - jagged-scrypt
+- jagged-ssh
 - jagged-test
 - jagged-x25519
 
@@ -224,6 +231,20 @@ a work factor with a minimum value of 2 and a maximum value of 20.
 
 The module includes a custom implementation of the scrypt key derivation function with predefined settings that
 match age encryption scrypt recipient specifications.
+
+## jagged-ssh
+
+The `jagged-ssh` module supports encryption and decryption using public and private SSH key pairs. The SSH key pair
+implementation is compatible with the [agessh](https://pkg.go.dev/filippo.io/age/agessh) package, which defines
+recipient stanzas with an algorithm and an encoded fingerprint of the public key.
+
+The `SshRsaRecipientStanzaReaderFactory` creates instances of `RecipientStanzaReader` using an RSA private key.
+
+The `SshRsaRecipientStanzaWriterFactory` creates instances of `RecipientStanzaWriter` using an RSA public key.
+
+The SSH RSA implementation uses Optimal Asymmetric Encryption Padding as defined in
+[RFC 8017 Section 7.1](https://www.rfc-editor.org/rfc/rfc8017#section-7.1). Following the age implementation, RSA OAEP
+cipher operations use `SHA-256` as the hash algorithm with the mask generation function.
 
 ## jagged-x25519
 

--- a/jagged-ssh/pom.xml
+++ b/jagged-ssh/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.exceptionfactory.jagged</groupId>
+        <artifactId>jagged</artifactId>
+        <version>0.3.3-SNAPSHOT</version>
+    </parent>
+
+    <name>jagged-ssh</name>
+    <artifactId>jagged-ssh</artifactId>
+    <description>Jagged SSH recipient support for age encryption</description>
+    <url>https://github.com/exceptionfactory/jagged</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.exceptionfactory.jagged</groupId>
+            <artifactId>jagged-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${project.groupId}.ssh</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/PublicKeyFingerprintProducer.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/PublicKeyFingerprintProducer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import java.security.GeneralSecurityException;
+
+/**
+ * Abstraction for generating fingerprints of Public Keys
+ */
+interface PublicKeyFingerprintProducer {
+    /**
+     * Get fingerprint from marshalled Public Key bytes
+     *
+     * @param marshalledPublicKey Marshalled public key
+     * @return Fingerprint label
+     * @throws GeneralSecurityException Thrown on failures to generate fingerprints
+     */
+    String getFingerprint(byte[] marshalledPublicKey) throws GeneralSecurityException;
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/PublicKeyMarshaller.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/PublicKeyMarshaller.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import java.security.PublicKey;
+
+/**
+ * SSH Public Key Marshaller abstraction for writing Public Key elements according to SSH wire format requirements
+ *
+ * @param <T> Public Key Type
+ */
+interface PublicKeyMarshaller<T extends PublicKey> {
+    /**
+     * Get Public Key marshalled according to SSH wire format requirements
+     *
+     * @param publicKey Public Key to be marshalled
+     * @return Byte array containing marshalled public key
+     */
+    byte[] getMarshalledKey(T publicKey);
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/RsaOaepCipherFactory.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/RsaOaepCipherFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.util.Objects;
+
+/**
+ * RSA OAEP Cipher Factory with algorithm selection matching age-ssh implementation
+ */
+class RsaOaepCipherFactory {
+    private static final String CIPHER_ALGORITHM = "RSA/ECB/OAEPPadding";
+
+    private static final String DIGEST_ALGORITHM = "SHA-256";
+
+    private static final String MGF_ALGORITHM = "MGF1";
+
+    private static final AlgorithmParameterSpec ALGORITHM_PARAMETER_SPEC = new MGF1ParameterSpec(DIGEST_ALGORITHM);
+
+    private static final byte[] ENCODING_INPUT = SshRsaRecipientIndicator.ENCODING_LABEL.getIndicator().getBytes(StandardCharsets.UTF_8);
+
+    private static final PSource ENCODING_SOURCE = new PSource.PSpecified(ENCODING_INPUT);
+
+    /**
+     * Get RSA OAEP initialized cipher based on Cipher Mode and Key
+     *
+     * @param cipherMode Cipher mode for encryption or decryption
+     * @param key Public or private key
+     * @return Initialized Cipher
+     * @throws GeneralSecurityException Thrown on initialization failures
+     */
+    Cipher getInitializedCipher(final CipherMode cipherMode, final Key key) throws GeneralSecurityException {
+        Objects.requireNonNull(cipherMode, "Cipher Mode required");
+        Objects.requireNonNull(key, "Key required");
+
+        final Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+
+        final OAEPParameterSpec parameterSpec = new OAEPParameterSpec(
+                DIGEST_ALGORITHM,
+                MGF_ALGORITHM,
+                ALGORITHM_PARAMETER_SPEC,
+                ENCODING_SOURCE
+        );
+
+        cipher.init(cipherMode.mode, key, parameterSpec);
+        return cipher;
+    }
+
+    enum CipherMode {
+        DECRYPT(Cipher.DECRYPT_MODE),
+
+        ENCRYPT(Cipher.ENCRYPT_MODE);
+
+        private final int mode;
+
+        CipherMode(final int mode) {
+            this.mode = mode;
+        }
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/RsaPublicKeyFactory.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/RsaPublicKeyFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import java.security.GeneralSecurityException;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+
+/**
+ * Abstraction for deriving RSA Public Keys from RSA Private Keys
+ */
+interface RsaPublicKeyFactory {
+    /**
+     * Get RSA Public Key
+     *
+     * @param privateKey RSA Private Key
+     * @return RSA Public Key
+     * @throws GeneralSecurityException Thrown on failure to convert private key to public key
+     */
+    RSAPublicKey getPublicKey(RSAPrivateCrtKey privateKey) throws GeneralSecurityException;
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaPublicKeyMarshaller.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaPublicKeyMarshaller.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Objects;
+
+/**
+ * SSH RSA implementation of Public Key Marshaller writes the RSA exponent and modulus along with the key algorithm
+ */
+class SshRsaPublicKeyMarshaller implements PublicKeyMarshaller<RSAPublicKey> {
+    private static final byte[] SSH_RSA_ALGORITHM = SshRsaRecipientIndicator.STANZA_TYPE.getIndicator().getBytes(StandardCharsets.UTF_8);
+
+    private static final int BUFFER_SIZE = 1024;
+
+    /**
+     * Get Public Key marshalled according to SSH wire format requirements
+     *
+     * @param publicKey RSA Public Key to be marshalled
+     * @return Byte array containing marshalled public key with ssh-rsa algorithm, exponent, and modulus
+     */
+    @Override
+    public byte[] getMarshalledKey(final RSAPublicKey publicKey) {
+        Objects.requireNonNull(publicKey, "RSA Public Key required");
+
+        final ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+        writeBytes(buffer, SSH_RSA_ALGORITHM);
+
+        final BigInteger publicExponent = publicKey.getPublicExponent();
+        writeBytes(buffer, publicExponent.toByteArray());
+
+        final BigInteger modulus = publicKey.getModulus();
+        writeBytes(buffer, modulus.toByteArray());
+
+        final byte[] marshalledKey = new byte[buffer.position()];
+        buffer.flip();
+        buffer.get(marshalledKey);
+        return marshalledKey;
+    }
+
+    private void writeBytes(final ByteBuffer buffer, final byte[] bytes) {
+        buffer.putInt(bytes.length);
+        buffer.put(bytes);
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientIndicator.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientIndicator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+/**
+ * SSH RSA Recipient Indicators for reading and writing Recipient Stanzas
+ */
+enum SshRsaRecipientIndicator {
+    /** SSH RSA Recipient Stanza Type */
+    STANZA_TYPE("ssh-rsa"),
+
+    /** Label used for RSA OAEP encryption */
+    ENCODING_LABEL("age-encryption.org/v1/ssh-rsa");
+
+    private final String indicator;
+
+    SshRsaRecipientIndicator(final String indicator) {
+        this.indicator = indicator;
+    }
+
+    public String getIndicator() {
+        return indicator;
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanza.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanza.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.RecipientStanza;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * SSH RSA Recipient Stanza with standard type and arguments containing encoded public key fingerprint
+ */
+class SshRsaRecipientStanza implements RecipientStanza {
+    private final List<String> arguments;
+
+    private final byte[] body;
+
+    SshRsaRecipientStanza(final String keyFingerprint, final byte[] body) {
+        Objects.requireNonNull(keyFingerprint, "Key fingerprint required");
+        this.arguments = Collections.singletonList(keyFingerprint);
+        this.body = Objects.requireNonNull(body, "Stanza Body required");
+    }
+
+    /**
+     * Get Recipient Stanza Type returns ssh-rsa
+     *
+     * @return SSH RSA Type
+     */
+    @Override
+    public String getType() {
+        return SshRsaRecipientIndicator.STANZA_TYPE.getIndicator();
+    }
+
+    /**
+     * Get Recipient Stanza Arguments containing the key fingerprint
+     *
+     * @return Recipient Stanza Arguments
+     */
+    @Override
+    public List<String> getArguments() {
+        return arguments;
+    }
+
+    /**
+     * Get Recipient Stanza Body containing encrypted File Key
+     *
+     * @return Encrypted File Key body
+     */
+    @Override
+    public byte[] getBody() {
+        return body.clone();
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReader.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReader.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.FileKey;
+import com.exceptionfactory.jagged.RecipientStanza;
+import com.exceptionfactory.jagged.RecipientStanzaReader;
+import com.exceptionfactory.jagged.UnsupportedRecipientStanzaException;
+
+import javax.crypto.Cipher;
+import java.security.GeneralSecurityException;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import static com.exceptionfactory.jagged.ssh.SshRsaRecipientIndicator.STANZA_TYPE;
+
+/**
+ * SSH RSA implementation of Recipient Stanza Reader compatible with age-ssh
+ */
+final class SshRsaRecipientStanzaReader implements RecipientStanzaReader {
+    private final RsaOaepCipherFactory cipherFactory = new RsaOaepCipherFactory();
+
+    private final RSAPrivateCrtKey privateKey;
+
+    private final String publicKeyFingerprint;
+
+    /**
+     * SSH RSA Recipient Stanza Reader with RSA Private Key for decryption of File Key
+     *
+     * @param privateKey RSA Private Key
+     * @throws GeneralSecurityException Thrown on failures to derive Public Key
+     */
+    SshRsaRecipientStanzaReader(final RSAPrivateCrtKey privateKey) throws GeneralSecurityException {
+        this.privateKey = Objects.requireNonNull(privateKey, "RSA Private Key required");
+
+        final RsaPublicKeyFactory rsaPublicKeyFactory = new StandardRsaPublicKeyFactory();
+        final RSAPublicKey publicKey = rsaPublicKeyFactory.getPublicKey(privateKey);
+        final SshRsaPublicKeyMarshaller publicKeyMarshaller = new SshRsaPublicKeyMarshaller();
+        final byte[] marshalledKey = publicKeyMarshaller.getMarshalledKey(publicKey);
+        final PublicKeyFingerprintProducer publicKeyFingerprintProducer = new StandardPublicKeyFingerprintProducer();
+        this.publicKeyFingerprint = publicKeyFingerprintProducer.getFingerprint(marshalledKey);
+    }
+
+    /**
+     * Get File Key from matching ssh-rsa Recipient Stanza
+     *
+     * @param recipientStanzas One or more Recipient Stanzas parsed from the age file header
+     * @return File Key decrypted from matching ssh-rsa Recipient Stanza arguments
+     * @throws GeneralSecurityException Thrown on failure to read or decrypt File Key
+     */
+    @Override
+    public FileKey getFileKey(final Iterable<RecipientStanza> recipientStanzas) throws GeneralSecurityException {
+        Objects.requireNonNull(recipientStanzas, "Recipient Stanzas required");
+
+        final List<Exception> exceptions = new ArrayList<>();
+        for (final RecipientStanza recipientStanza : recipientStanzas) {
+            final String recipientStanzaType = recipientStanza.getType();
+            if (STANZA_TYPE.getIndicator().equals(recipientStanzaType)) {
+                try {
+                    return getFileKey(recipientStanza);
+                } catch (final Exception e) {
+                    exceptions.add(e);
+                }
+            }
+        }
+
+        if (exceptions.isEmpty()) {
+            throw new UnsupportedRecipientStanzaException(String.format("%s Recipient Stanzas not found", STANZA_TYPE.getIndicator()));
+        } else {
+            final String message = String.format("%s Recipient Stanza not matched", STANZA_TYPE.getIndicator());
+            final UnsupportedRecipientStanzaException exception = new UnsupportedRecipientStanzaException(message);
+            exceptions.forEach(exception::addSuppressed);
+            throw exception;
+        }
+    }
+
+    private FileKey getFileKey(final RecipientStanza recipientStanza) throws GeneralSecurityException {
+        final Iterator<String> arguments = recipientStanza.getArguments().iterator();
+        final String recipientKeyFingerprint = getRecipientKeyFingerprint(arguments);
+
+        if (arguments.hasNext()) {
+            final String message = String.format("%s Recipient Stanza extra argument not expected", STANZA_TYPE.getIndicator());
+            throw new UnsupportedRecipientStanzaException(message);
+        }
+
+        if (publicKeyFingerprint.equals(recipientKeyFingerprint)) {
+            final byte[] encryptedFileKeyEncoded = recipientStanza.getBody();
+            final Cipher cipher = cipherFactory.getInitializedCipher(RsaOaepCipherFactory.CipherMode.DECRYPT, privateKey);
+            final byte[] fileKeyEncoded = cipher.doFinal(encryptedFileKeyEncoded);
+            return new FileKey(fileKeyEncoded);
+        } else {
+            final String message = String.format("%s Recipient Stanza Key Fingerprint [%s] not match", STANZA_TYPE.getIndicator(), recipientKeyFingerprint);
+            throw new UnsupportedRecipientStanzaException(message);
+        }
+    }
+
+    private String getRecipientKeyFingerprint(final Iterator<String> arguments) throws UnsupportedRecipientStanzaException {
+        if (arguments.hasNext()) {
+            return arguments.next();
+        } else {
+            throw new UnsupportedRecipientStanzaException("Key Fingerprint argument not found");
+        }
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReaderFactory.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReaderFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.RecipientStanzaReader;
+
+import java.security.GeneralSecurityException;
+import java.security.interfaces.RSAPrivateCrtKey;
+
+/**
+ * Factory abstraction for returning initialized ssh-rsa Recipient Stanza Readers from an RSA Private Key
+ */
+public final class SshRsaRecipientStanzaReaderFactory {
+    private SshRsaRecipientStanzaReaderFactory() {
+
+    }
+
+    /**
+     * Create new ssh-rsa Recipient Stanza Reader using an RSA Private CRT Key
+     *
+     * @param rsaPrivateCrtKey RSA Private CRT Key
+     * @return ssh-rsa Recipient Stanza Reader
+     * @throws GeneralSecurityException Thrown on failures to process public key from private key
+     */
+    public static RecipientStanzaReader newRecipientStanzaReader(final RSAPrivateCrtKey rsaPrivateCrtKey) throws GeneralSecurityException {
+        return new SshRsaRecipientStanzaReader(rsaPrivateCrtKey);
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriter.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.FileKey;
+import com.exceptionfactory.jagged.RecipientStanza;
+import com.exceptionfactory.jagged.RecipientStanzaWriter;
+
+import javax.crypto.Cipher;
+import java.security.GeneralSecurityException;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Collections;
+import java.util.Objects;
+
+/**
+ * SSH RSA implementation of Recipient Stanza Writer compatible with age-ssh
+ */
+class SshRsaRecipientStanzaWriter implements RecipientStanzaWriter {
+    private final SshRsaPublicKeyMarshaller publicKeyMarshaller = new SshRsaPublicKeyMarshaller();
+
+    private final PublicKeyFingerprintProducer publicKeyFingerprintProducer = new StandardPublicKeyFingerprintProducer();
+
+    private final RsaOaepCipherFactory cipherFactory = new RsaOaepCipherFactory();
+
+    private final RSAPublicKey rsaPublicKey;
+
+    /**
+     * SSH RSA Recipient Stanza Writer with RSA Public Key
+     *
+     * @param rsaPublicKey RSA Public Key for recipient of encrypted File Key
+     */
+    SshRsaRecipientStanzaWriter(final RSAPublicKey rsaPublicKey) {
+        this.rsaPublicKey = Objects.requireNonNull(rsaPublicKey, "RSA Public Key required");
+    }
+
+    /**
+     * Get Recipient Stanzas containing one ssh-rsa Recipient Stanza with the encrypted File Key
+     *
+     * @param fileKey File Key to be encrypted
+     * @return Singleton List of ssh-rsa Recipient Stanza with encrypted File Key
+     * @throws GeneralSecurityException Thrown key derivation or encryption failures
+     */
+    @Override
+    public Iterable<RecipientStanza> getRecipientStanzas(final FileKey fileKey) throws GeneralSecurityException {
+        Objects.requireNonNull(fileKey, "File Key required");
+
+        final byte[] marshalledKey = publicKeyMarshaller.getMarshalledKey(rsaPublicKey);
+        final String keyFingerprint = publicKeyFingerprintProducer.getFingerprint(marshalledKey);
+        final Cipher cipher = cipherFactory.getInitializedCipher(RsaOaepCipherFactory.CipherMode.ENCRYPT, rsaPublicKey);
+        final byte[] encryptedFileKey = cipher.doFinal(fileKey.getEncoded());
+
+        final RecipientStanza recipientStanza = new SshRsaRecipientStanza(keyFingerprint, encryptedFileKey);
+        return Collections.singletonList(recipientStanza);
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriterFactory.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriterFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.RecipientStanzaWriter;
+
+import java.security.interfaces.RSAPublicKey;
+
+/**
+ * Factory abstraction for returning initialized ssh-rsa Recipient Stanza Writer from an RSA Public Key
+ */
+public final class SshRsaRecipientStanzaWriterFactory {
+    private SshRsaRecipientStanzaWriterFactory() {
+
+    }
+
+    /**
+     * Create new ssh-rsa Recipient Stanza Writer using an RSA Public Key
+     *
+     * @param rsaPublicKey RSA Public Key
+     * @return ssh-rsa Recipient Stanza Writer
+     */
+    public static RecipientStanzaWriter newRecipientStanzaWriter(final RSAPublicKey rsaPublicKey) {
+        return new SshRsaRecipientStanzaWriter(rsaPublicKey);
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/StandardPublicKeyFingerprintProducer.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/StandardPublicKeyFingerprintProducer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Standard implementation of Public Key Fingerprint Producer using SHA-256 with Base64 encoding for first four bytes
+ */
+class StandardPublicKeyFingerprintProducer implements PublicKeyFingerprintProducer {
+    private static final String DIGEST_ALGORITHM = "SHA-256";
+
+    private static final int FINGERPRINT_DIGEST_LENGTH = 4;
+
+    private static final Base64.Encoder ENCODER = Base64.getEncoder().withoutPadding();
+
+    /**
+     * Get fingerprint from marshalled Public Key bytes following age-ssh implementation
+     *
+     * @param marshalledPublicKey Marshalled public key
+     * @return Fingerprint consisting of Base64 encoding of first four bytes from SHA-256 digest of public key
+     * @throws GeneralSecurityException Thrown on failures to get Message Digest for fingerprinting
+     */
+    @Override
+    public String getFingerprint(final byte[] marshalledPublicKey) throws GeneralSecurityException {
+        final MessageDigest messageDigest = getMessageDigest();
+        final byte[] digest = messageDigest.digest(marshalledPublicKey);
+        final byte[] fingerprintDigest = Arrays.copyOfRange(digest, 0, FINGERPRINT_DIGEST_LENGTH);
+        return ENCODER.encodeToString(fingerprintDigest);
+    }
+
+    private MessageDigest getMessageDigest() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance(DIGEST_ALGORITHM);
+    }
+}

--- a/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/StandardRsaPublicKeyFactory.java
+++ b/jagged-ssh/src/main/java/com/exceptionfactory/jagged/ssh/StandardRsaPublicKeyFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Objects;
+
+/**
+ * Standard implementation of RSA Public Key Factory
+ */
+class StandardRsaPublicKeyFactory implements RsaPublicKeyFactory {
+    /**
+     * Get RSA Public Key
+     *
+     * @param privateKey RSA Private Key
+     * @return RSA Public Key
+     * @throws GeneralSecurityException Thrown on failure to convert private key to public key
+     */
+    @Override
+    public RSAPublicKey getPublicKey(final RSAPrivateCrtKey privateKey) throws GeneralSecurityException {
+        Objects.requireNonNull(privateKey, "RSA Private Key required");
+
+        final KeyFactory keyFactory = KeyFactory.getInstance(privateKey.getAlgorithm());
+        final RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(privateKey.getModulus(), privateKey.getPublicExponent());
+        return (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
+    }
+}

--- a/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/RsaKeyPairProvider.java
+++ b/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/RsaKeyPairProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+
+final class RsaKeyPairProvider {
+    private static final String KEY_ALGORITHM = "RSA";
+
+    private static final int KEY_SIZE = 4096;
+
+    private static RSAPublicKey rsaPublicKey;
+
+    private static RSAPrivateCrtKey rsaPrivateCrtKey;
+
+    private RsaKeyPairProvider() {
+
+    }
+
+    static synchronized RSAPublicKey getRsaPublicKey() throws NoSuchAlgorithmException {
+        if (rsaPublicKey == null) {
+            setKeyPair();
+        }
+        return rsaPublicKey;
+    }
+
+    static synchronized RSAPrivateCrtKey getRsaPrivateCrtKey() throws NoSuchAlgorithmException {
+        if (rsaPrivateCrtKey == null) {
+            setKeyPair();
+        }
+        return rsaPrivateCrtKey;
+    }
+
+    private static void setKeyPair() throws NoSuchAlgorithmException {
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGORITHM);
+        keyPairGenerator.initialize(KEY_SIZE);
+        final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        rsaPublicKey = (RSAPublicKey) keyPair.getPublic();
+        rsaPrivateCrtKey = (RSAPrivateCrtKey) keyPair.getPrivate();
+    }
+}

--- a/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaPublicKeyMarshallerTest.java
+++ b/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaPublicKeyMarshallerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SshRsaPublicKeyMarshallerTest {
+    private static final BigInteger PUBLIC_EXPONENT = BigInteger.valueOf(65537);
+
+    private static final int EXPECTED_LENGTH = 23;
+
+    private static final byte[] SSH_RSA_ALGORITHM_SERIALIZED = {0, 0, 0, 7, 115, 115, 104, 45, 114, 115, 97};
+
+    @Mock
+    private RSAPublicKey publicKey;
+
+    private SshRsaPublicKeyMarshaller marshaller;
+
+    @BeforeEach
+    void setMarshaller() {
+        marshaller = new SshRsaPublicKeyMarshaller();
+    }
+
+    @Test
+    void testGetMarshalledKey() {
+        when(publicKey.getPublicExponent()).thenReturn(PUBLIC_EXPONENT);
+        when(publicKey.getModulus()).thenReturn(BigInteger.TEN);
+
+        final byte[] marshalledKey = marshaller.getMarshalledKey(publicKey);
+
+        assertNotNull(marshalledKey);
+        assertEquals(EXPECTED_LENGTH, marshalledKey.length);
+
+        final byte[] algorithm = Arrays.copyOfRange(marshalledKey, 0, SSH_RSA_ALGORITHM_SERIALIZED.length);
+        assertArrayEquals(SSH_RSA_ALGORITHM_SERIALIZED, algorithm);
+    }
+}

--- a/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReaderFactoryTest.java
+++ b/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReaderFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.RecipientStanzaReader;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateCrtKey;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SshRsaRecipientStanzaReaderFactoryTest {
+    private static RSAPrivateCrtKey rsaPrivateKey;
+
+    @BeforeAll
+    static void setRsaPrivateKey() throws NoSuchAlgorithmException {
+        rsaPrivateKey = RsaKeyPairProvider.getRsaPrivateCrtKey();
+    }
+
+    @Test
+    void testNewRecipientStanzaReader() throws GeneralSecurityException {
+        final RecipientStanzaReader reader = SshRsaRecipientStanzaReaderFactory.newRecipientStanzaReader(rsaPrivateKey);
+
+        assertNotNull(reader);
+    }
+}

--- a/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReaderTest.java
+++ b/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaReaderTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.FileKey;
+import com.exceptionfactory.jagged.RecipientStanza;
+import com.exceptionfactory.jagged.UnsupportedRecipientStanzaException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SshRsaRecipientStanzaReaderTest {
+    private static final String REJECTED = String.class.getSimpleName();
+
+    private static FileKey fileKey;
+
+    private static RSAPublicKey rsaPublicKey;
+
+    private static RSAPrivateCrtKey rsaPrivateKey;
+
+    @Mock
+    private RecipientStanza recipientStanza;
+
+    private SshRsaRecipientStanzaWriter writer;
+
+    private SshRsaRecipientStanzaReader reader;
+
+    @BeforeAll
+    static void setFileKey() throws NoSuchAlgorithmException {
+        fileKey = new FileKey();
+        rsaPublicKey = RsaKeyPairProvider.getRsaPublicKey();
+        rsaPrivateKey = RsaKeyPairProvider.getRsaPrivateCrtKey();
+    }
+
+    @BeforeEach
+    void setWriter() throws GeneralSecurityException {
+        writer = new SshRsaRecipientStanzaWriter(rsaPublicKey);
+        reader = new SshRsaRecipientStanzaReader(rsaPrivateKey);
+    }
+
+    @Test
+    void testGetFileKeyEmptyRecipientStanzas() {
+        assertThrows(UnsupportedRecipientStanzaException.class, () -> reader.getFileKey(Collections.emptyList()));
+    }
+
+    @Test
+    void testGetFileKeyRecipientStanzaTypeRejected()  {
+        final List<RecipientStanza> stanzas = Collections.singletonList(recipientStanza);
+        when(recipientStanza.getType()).thenReturn(REJECTED);
+
+        assertThrows(UnsupportedRecipientStanzaException.class, () -> reader.getFileKey(stanzas));
+    }
+
+    @Test
+    void testGetFileKeyRecipientStanzaKeyFingerprintNotFound()  {
+        final List<RecipientStanza> stanzas = Collections.singletonList(recipientStanza);
+        when(recipientStanza.getType()).thenReturn(SshRsaRecipientIndicator.STANZA_TYPE.getIndicator());
+        when(recipientStanza.getArguments()).thenReturn(Collections.emptyList());
+
+        assertThrows(UnsupportedRecipientStanzaException.class, () -> reader.getFileKey(stanzas));
+    }
+
+    @Test
+    void testGetFileKeyRecipientStanzaKeyFingerprintNotMatched()  {
+        final List<RecipientStanza> stanzas = Collections.singletonList(recipientStanza);
+        when(recipientStanza.getType()).thenReturn(SshRsaRecipientIndicator.STANZA_TYPE.getIndicator());
+        when(recipientStanza.getArguments()).thenReturn(Collections.singletonList(REJECTED));
+
+        assertThrows(UnsupportedRecipientStanzaException.class, () -> reader.getFileKey(stanzas));
+    }
+
+    @Test
+    void testGetFileKeyExtraArgumentFound() {
+        final List<RecipientStanza> stanzas = Collections.singletonList(recipientStanza);
+        when(recipientStanza.getType()).thenReturn(SshRsaRecipientIndicator.STANZA_TYPE.getIndicator());
+        when(recipientStanza.getArguments()).thenReturn(Arrays.asList(REJECTED, REJECTED));
+
+        assertThrows(UnsupportedRecipientStanzaException.class, () -> reader.getFileKey(stanzas));
+    }
+
+    @Test
+    void testGetFileKey() throws GeneralSecurityException {
+        final Iterable<RecipientStanza> recipientStanzas = writer.getRecipientStanzas(fileKey);
+
+        assertNotNull(recipientStanzas);
+
+        final FileKey fileKeyRead = reader.getFileKey(recipientStanzas);
+
+        assertNotNull(fileKeyRead);
+        assertArrayEquals(fileKey.getEncoded(), fileKeyRead.getEncoded());
+    }
+}

--- a/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriterFactoryTest.java
+++ b/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriterFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.RecipientStanzaWriter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SshRsaRecipientStanzaWriterFactoryTest {
+    private static RSAPublicKey rsaPublicKey;
+
+    @BeforeAll
+    static void setRsaPublicKey() throws NoSuchAlgorithmException {
+        rsaPublicKey = RsaKeyPairProvider.getRsaPublicKey();
+    }
+
+    @Test
+    void testNewRecipientStanzaWriter() {
+        final RecipientStanzaWriter writer = SshRsaRecipientStanzaWriterFactory.newRecipientStanzaWriter(rsaPublicKey);
+
+        assertNotNull(writer);
+    }
+}

--- a/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriterTest.java
+++ b/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/SshRsaRecipientStanzaWriterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import com.exceptionfactory.jagged.FileKey;
+import com.exceptionfactory.jagged.RecipientStanza;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SshRsaRecipientStanzaWriterTest {
+    private static final int FINGERPRINT_LENGTH = 6;
+
+    private static final int EXPECTED_BODY_LENGTH = 512;
+
+    private static FileKey fileKey;
+
+    private static RSAPublicKey rsaPublicKey;
+
+    private SshRsaRecipientStanzaWriter writer;
+
+    @BeforeAll
+    static void setFileKey() throws NoSuchAlgorithmException {
+        fileKey = new FileKey();
+        rsaPublicKey = RsaKeyPairProvider.getRsaPublicKey();
+    }
+
+    @BeforeEach
+    void setWriter() {
+        writer = new SshRsaRecipientStanzaWriter(rsaPublicKey);
+    }
+
+    @Test
+    void testGetRecipientStanzas() throws GeneralSecurityException {
+        final Iterable<RecipientStanza> recipientStanzas = writer.getRecipientStanzas(fileKey);
+
+        assertNotNull(recipientStanzas);
+
+        final Iterator<RecipientStanza> stanzas = recipientStanzas.iterator();
+        assertTrue(stanzas.hasNext());
+
+        final RecipientStanza recipientStanza = stanzas.next();
+        final byte[] body = recipientStanza.getBody();
+        assertNotNull(body);
+        assertEquals(EXPECTED_BODY_LENGTH, body.length);
+
+        assertFalse(stanzas.hasNext());
+        assertEquals(SshRsaRecipientIndicator.STANZA_TYPE.getIndicator(), recipientStanza.getType());
+
+        final Iterator<String> arguments = recipientStanza.getArguments().iterator();
+        assertTrue(arguments.hasNext());
+
+        final String fingerprint = arguments.next();
+        assertFalse(arguments.hasNext());
+        assertNotNull(fingerprint);
+        assertEquals(FINGERPRINT_LENGTH, fingerprint.length());
+    }
+}

--- a/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/StandardPublicKeyFingerprintProducerTest.java
+++ b/jagged-ssh/src/test/java/com/exceptionfactory/jagged/ssh/StandardPublicKeyFingerprintProducerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Jagged Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exceptionfactory.jagged.ssh;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.GeneralSecurityException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StandardPublicKeyFingerprintProducerTest {
+    private static final byte[] PUBLIC_KEY = {0, 1, 2, 3};
+
+    private static final String EXPECTED_FINGERPRINT = "BU7ewQ";
+
+    private StandardPublicKeyFingerprintProducer fingerprintProducer;
+
+    @BeforeEach
+    void setFingerprintProducer() {
+        fingerprintProducer = new StandardPublicKeyFingerprintProducer();
+    }
+
+    @Test
+    void testGetFingerprint() throws GeneralSecurityException {
+        final String fingerprint = fingerprintProducer.getFingerprint(PUBLIC_KEY);
+
+        assertNotNull(fingerprint);
+        assertEquals(EXPECTED_FINGERPRINT, fingerprint);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <module>jagged-bom</module>
         <module>jagged-framework</module>
         <module>jagged-scrypt</module>
+        <module>jagged-ssh</module>
         <module>jagged-test</module>
         <module>jagged-x25519</module>
     </modules>


### PR DESCRIPTION
This pull request adds a `jagged-ssh` module with initial support for the `ssh-rsa` recipient type.

The SSH RSA implementation uses RSA-OAEP for encrypting File Keys following the design of the [agessh](https://pkg.go.dev/filippo.io/age/agessh) package.

The initial implementation requires instances of [RSAPublicKey](https://docs.oracle.com/javase/8/docs/api/java/security/interfaces/RSAPublicKey.html) for Recipient Stanza Writers, and instances of [RSAPrivateCrtKey](https://docs.oracle.com/javase/8/docs/api/java/security/interfaces/RSAPrivateCrtKey.html) for Recipient Stanza Readers.